### PR TITLE
feat: expand issue fetching to include all open tasks and recent issues

### DIFF
--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -203,7 +203,7 @@ export function TaskList({
             <AlertCircle className="w-8 h-8 text-purple-400" />
           </div>
           <h3 className="text-lg font-medium text-white mb-2">No tasks found</h3>
-          <p className="text-gray-400">No tasks found for the current month</p>
+          <p className="text-gray-400">No tasks found for the current and previous month</p>
         </div>
       )}
     </div>


### PR DESCRIPTION
- Fetch all open issues regardless of creation date
- Include issues created in current and previous month
- Merge and deduplicate results by issue ID
- Sort issues by creation date (newest first)
- Update UI message to reflect expanded date range

This ensures users see all active work plus any recent tasks from the past two months.